### PR TITLE
remote scripts refactored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ TESTPORT=8098
 PRODPORT=8099
 RSYNC=rsync -avP --stats -e ssh
 
+corpbasename := corbama-ud
+corpsite := corbama
+corpora := corbama-ud
+include remote.mk
+
 corpusfiles := $(wildcard conllu/*.conllu)
 vertfiles := $(patsubst conllu/%.conllu,vert/%.vert,$(corpusfiles))
 rawfiles := $(filter-out $(patsubst conllu/%,raw/%,$(corpusfiles)), $(patsubst html/%.html,raw/%.conllu,$(wildcard html/*.html)))
@@ -35,54 +40,3 @@ compile: corbama-ud.vert config/corbama-ud
 	cp config/corbama-ud export/registry/
 	bash -c "pushd export ; tar cJvf corbama-ud.tar.xz --mode='a+r' * ; popd"
 
-get-remote-scripts:
-	mkdir -p remote
-	wget -P remote https://raw.githubusercontent.com/maslinych/corbama-build/master/remote/create-hsh.sh
-	wget -P remote https://raw.githubusercontent.com/maslinych/corbama-build/master/remote/setup-bonito.sh
-	wget -P remote https://raw.githubusercontent.com/maslinych/corbama-build/master/remote/setup-corpus-environment.sh
-	wget -P remote https://raw.githubusercontent.com/maslinych/corbama-build/master/remote/testing2production.sh
-
-
-create-testing:
-	ssh $(HOST) 'test -d $(TESTING) || mkdir $(TESTING)'
-	$(RSYNC) remote/*.sh $(HOST):
-	ssh $(HOST) sh -x create-hsh.sh $(TESTING) $(TESTPORT)
-
-setup-bonito:
-	ssh $(HOST) hsh-run --rooter $(TESTING) -- 'sh setup-bonito.sh corbama corbama-ud' 
-
-install-testing: 
-	$(RSYNC) export/corbama-ud.tar.xz $(HOST):$(TESTING)/chroot/.in/
-	ssh $(HOST) hsh-run --rooter $(TESTING) -- 'rm -rf /var/lib/manatee/{data,registry,vert}/corbama-ud*'
-	ssh $(HOST) hsh-run --rooter $(TESTING) -- 'tar --no-same-permissions --no-same-owner -xJvf corbama-ud.tar.xz --directory /var/lib/manatee'
-
-start-%:
-	ssh $(HOST) tmux new-session -d -s $* \"export share_network=1 \; hsh-shell --root --mount=/proc $*\"
-	sleep 5
-	ssh $(HOST) tmux send-keys -t $*:0 \"service httpd2 start\" Enter
-
-stop-%:
-	ssh $(HOST) tmux send-keys -t $*:0 \"service httpd2 stop\" Enter
-	ssh $(HOST) tmux kill-session -t $*
-
-production: stop-production stop-testing
-	$(RSYNC) remote/testing2production.sh $(HOST):$(TESTING)/chroot/.in/
-	ssh $(HOST) hsh-run --rooter $(TESTING) -- 'sh testing2production.sh $(TESTPORT) $(PRODPORT)'
-	ssh $(HOST) sh -c 'test -d $(ROLLBACK)/chroot && hsh --clean $(ROLLBACK) || echo empty rollback'
-	ssh $(HOST) rm -rf $(ROLLBACK)
-	ssh $(HOST) mv $(PRODUCTION) $(ROLLBACK)
-	ssh $(HOST) mv $(TESTING) $(PRODUCTION)
-
-rollback: stop-production
-	$(RSYNC) remote/testing2production.sh $(HOST):$(PRODUCTION)/chroot/.in/
-	ssh $(HOST) hsh-run --rooter $(PRODUCTION) -- 'sh testing2production.sh $(PRODPORT) $(TESTPORT)'
-	ssh $(HOST) sh -c 'test -d $(TESTING)/chroot && hsh --clean $(TESTING)'
-	ssh $(HOST) rm -rf $(TESTING)
-	ssh $(HOST) mv $(PRODUCTION) $(TESTING)
-	ssh $(HOST) mv $(ROLLBACK) $(PRODUCTION)
-
-update-corpus:
-	make compile
-	make stop-testing
-	make install-testing
-	make start-testing

--- a/remote.mk
+++ b/remote.mk
@@ -1,0 +1,49 @@
+install-remote-scripts:
+	$(RSYNC) remote/*.sh $(HOST):bin
+
+create-testing: install-remote-scripts
+	ssh $(HOST) "bin/create-hsh.sh"
+	ssh $(HOST) "bin/install-all-corpora.sh"
+	ssh $(HOST) "bin/setup-all-corpora.sh"
+
+setup-bonito: install-remote-scripts
+	ssh $(HOST) "bin/setup-corpus.sh $(corpsite) $(corpora)"
+
+install-testing: export/$(corpbasename).tar.xz
+	$(RSYNC) $< $(HOST):$(BUILT)/
+	ssh $(HOST) "echo $(corpsite) $(corpora) > $(BUILT)/$(corpbasename).setup.txt"
+	ssh $(HOST) "bin/install-corpus.sh $(corpbasename)"
+
+uninstall-testing:
+	ssh $(HOST) "rm -f $(BUILT)/$(corpbasename).tar.xz"
+	ssh $(HOST) "rm -f $(BUILT)/$(corpbasename).setup.txt"
+
+start-%:
+	ssh $(HOST) "bin/start-env.sh $*"
+
+stop-%:
+	ssh $(HOST) "bin/stop-env.sh $*"
+
+update-corpus:
+	make compile
+	make stop-testing
+	make install-testing
+	make start-testing
+
+production: stop-production stop-testing
+	$(RSYNC) remote/testing2production.sh $(HOST):$(TESTING)/chroot/.in/
+	ssh $(HOST) hsh-run --rooter $(TESTING) -- 'sh testing2production.sh $(TESTPORT) $(PRODPORT)'
+	ssh $(HOST) sh -c 'test -d $(ROLLBACK)/chroot && hsh --clean $(ROLLBACK) || echo empty rollback'
+	ssh $(HOST) rm -rf $(ROLLBACK)
+	ssh $(HOST) mv $(PRODUCTION) $(ROLLBACK)
+	ssh $(HOST) mv $(TESTING) $(PRODUCTION)
+
+rollback: stop-production
+	$(RSYNC) remote/testing2production.sh $(HOST):$(PRODUCTION)/chroot/.in/
+	ssh $(HOST) hsh-run --rooter $(PRODUCTION) -- 'sh testing2production.sh $(PRODPORT) $(TESTPORT)'
+	ssh $(HOST) sh -c 'test -d $(TESTING)/chroot && hsh --clean $(TESTING)'
+	ssh $(HOST) rm -rf $(TESTING)
+	ssh $(HOST) mv $(PRODUCTION) $(TESTING)
+	ssh $(HOST) mv $(ROLLBACK) $(PRODUCTION)
+
+

--- a/remote.mk
+++ b/remote.mk
@@ -1,3 +1,9 @@
+remote-setup:
+	@echo Remote host: $(HOST)
+	@echo Corpus archive basename: $(corpbasename)
+	@echo Corpus site name: $(corpsite)
+	@echo A list of corpora to be installed: $(corpora)
+
 install-remote-scripts:
 	$(RSYNC) remote/*.sh $(HOST):bin
 


### PR DESCRIPTION
Переработана инфраструктура публикации корпусов: теперь поддерживается восстановление всех ранее установленных в testing корпусов при выполнении create-testing. Для удобства сопровождения make targets для управления установкой корпуса вынесены в отдельный файл remote.mk.